### PR TITLE
feat: add simple OKX API emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # okx-emulation-api
+
+이 프로젝트는 OKX 거래소의 REST API를 간단히 에뮬레이션하여, 테스트 환경에서 코인 시세를 임의로 설정하고 조회할 수 있게 합니다.
+
+## 사용법
+
+### 설치
+```
+npm install
+```
+
+### 서버 실행
+```
+npm start
+```
+
+### 시세 설정
+```
+curl -X POST http://localhost:3000/admin/set-price \
+  -H "Content-Type: application/json" \
+  -d '{"instId":"BTC-USDT","price":30000}'
+```
+
+### 시세 조회
+```
+curl "http://localhost:3000/api/v5/market/ticker?instId=BTC-USDT"
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "okx-emulation-api",
+  "version": "1.0.0",
+  "description": "Simple OKX API emulator for testing with customizable coin prices",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const app = express();
+app.use(express.json());
+
+const prices = {};
+
+app.get('/api/v5/market/ticker', (req, res) => {
+  const { instId } = req.query;
+  const price = prices[instId] || '0';
+  res.json({
+    code: '0',
+    msg: '',
+    data: [
+      {
+        instId,
+        last: price.toString()
+      }
+    ]
+  });
+});
+
+app.post('/admin/set-price', (req, res) => {
+  const { instId, price } = req.body;
+  if (!instId || price === undefined) {
+    return res.status(400).json({ error: 'instId and price required' });
+  }
+  prices[instId] = price;
+  res.json({ instId, price });
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`OKX emulator running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- implement minimal OKX REST API emulator with Express
- allow setting and retrieving arbitrary coin prices for testing

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden to fetch express)*

------
https://chatgpt.com/codex/tasks/task_e_68a0791dc3148330a988f83e3918b451