### PR TITLE
확장된 OKX 티커 API 에뮬레이션

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -21,7 +21,19 @@ curl -X POST http://localhost:3000/admin/set-price \
   -d '{"instId":"BTC-USDT","price":30000}'
 ```
 
+### 상세 티커 설정
+```bash
+curl -X POST http://localhost:3000/admin/set-ticker \
+  -H "Content-Type: application/json" \
+  -d '{"instId":"BTC-USDT","instType":"SPOT","last":30000,"askPx":30001,"bidPx":29999}'
+```
+
 ### 시세 조회
 ```
 curl "http://localhost:3000/api/v5/market/ticker?instId=BTC-USDT"
+```
+
+### 여러 상품의 티커 조회
+```bash
+curl "http://localhost:3000/api/v5/market/tickers?instType=SPOT"
 ```

--- a/server.js
+++ b/server.js
@@ -2,30 +2,78 @@ const express = require('express');
 const app = express();
 app.use(express.json());
 
-const prices = {};
+// 티커 정보를 저장하기 위한 메모리 객체
+const tickers = {};
 
+// 개별 상품의 티커 정보 조회
 app.get('/api/v5/market/ticker', (req, res) => {
   const { instId } = req.query;
-  const price = prices[instId] || '0';
-  res.json({
-    code: '0',
-    msg: '',
-    data: [
-      {
-        instId,
-        last: price.toString()
-      }
-    ]
-  });
+  const ticker = tickers[instId] || {};
+  const data = {
+    instType: ticker.instType || '',
+    instId,
+    last: (ticker.last ?? 0).toString(),
+    lastSz: (ticker.lastSz ?? 0).toString(),
+    askPx: (ticker.askPx ?? 0).toString(),
+    askSz: (ticker.askSz ?? 0).toString(),
+    bidPx: (ticker.bidPx ?? 0).toString(),
+    bidSz: (ticker.bidSz ?? 0).toString(),
+    open24h: (ticker.open24h ?? 0).toString(),
+    high24h: (ticker.high24h ?? 0).toString(),
+    low24h: (ticker.low24h ?? 0).toString(),
+    volCcy24h: (ticker.volCcy24h ?? 0).toString(),
+    vol24h: (ticker.vol24h ?? 0).toString(),
+    ts: (ticker.ts ?? Date.now()).toString()
+  };
+  res.json({ code: '0', msg: '', data: [data] });
 });
 
+// 다수 상품의 티커 정보 조회
+app.get('/api/v5/market/tickers', (req, res) => {
+  const { instType } = req.query;
+  const data = Object.values(tickers)
+    .filter(t => !instType || t.instType === instType)
+    .map(t => ({
+      instType: t.instType || '',
+      instId: t.instId,
+      last: (t.last ?? 0).toString(),
+      lastSz: (t.lastSz ?? 0).toString(),
+      askPx: (t.askPx ?? 0).toString(),
+      askSz: (t.askSz ?? 0).toString(),
+      bidPx: (t.bidPx ?? 0).toString(),
+      bidSz: (t.bidSz ?? 0).toString(),
+      open24h: (t.open24h ?? 0).toString(),
+      high24h: (t.high24h ?? 0).toString(),
+      low24h: (t.low24h ?? 0).toString(),
+      volCcy24h: (t.volCcy24h ?? 0).toString(),
+      vol24h: (t.vol24h ?? 0).toString(),
+      ts: (t.ts ?? Date.now()).toString()
+    }));
+  res.json({ code: '0', msg: '', data });
+});
+
+// 간단한 가격 설정 (last 값만 변경)
 app.post('/admin/set-price', (req, res) => {
   const { instId, price } = req.body;
   if (!instId || price === undefined) {
     return res.status(400).json({ error: 'instId and price required' });
   }
-  prices[instId] = price;
+  const ticker = tickers[instId] || { instId };
+  ticker.last = price;
+  tickers[instId] = ticker;
   res.json({ instId, price });
+});
+
+// 상세 티커 정보 설정
+app.post('/admin/set-ticker', (req, res) => {
+  const { instId } = req.body;
+  if (!instId) {
+    return res.status(400).json({ error: 'instId required' });
+  }
+  const ticker = tickers[instId] || { instId };
+  Object.assign(ticker, req.body);
+  tickers[instId] = ticker;
+  res.json(ticker);
 });
 
 const port = process.env.PORT || 3000;


### PR DESCRIPTION
## 요약
- 메모리 기반 티커 저장소와 단일/다중 티커 조회 엔드포인트 추가
- 가격 및 상세 티커 정보를 설정하는 관리용 엔드포인트 구현
- 사용 예시와 엔드포인트 설명을 README에 확장

## 테스트
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a07c6325348330923f3a38596287f0